### PR TITLE
Add option 'notifydel'

### DIFF
--- a/inc/telegramclient.rb
+++ b/inc/telegramclient.rb
@@ -28,6 +28,7 @@ HELP_GATE_CMD = %q{Available commands:
     timezone <timezone> — adjust timezone for Telegram user statuses (example: +02:00)
     keeponline <bool> — always keep telegram session online and rely on jabber offline messages (example: true)
     rawmessages <bool> — do not add additional info (message id, origin etc.) to incoming messages (example: true)
+    notifydel <bool> — send info (message id) about deleted messages (example: true)
 }
 
 HELP_CHAT_CMD= %q{Available commands:
@@ -206,7 +207,7 @@ class TelegramClient
     ##  message(s) deleted 
     def update_deletemessages(update)
         text = "✗ %s" % update.message_ids.join(',')
-        @xmpp.send_message(@jid, update.chat_id, text) if update.is_permanent
+        @xmpp.send_message(@jid, update.chat_id, text) if update.is_permanent unless @session[:notifydel] == 'false'
     end
     
     ##  new chat discovered 


### PR DESCRIPTION
When user has many chats with enabled message autodelete, he gots very much annoying notifications with pointless information. He already knows when and which messages will be deleted. As solution I can suggest to add new option in account configuration where user could choose, does he wants to see notifications about deleted messages or not. By default it will show notifications.